### PR TITLE
Checked decomposition_msld

### DIFF
--- a/R/decomposition_msld.R
+++ b/R/decomposition_msld.R
@@ -8,17 +8,19 @@
 #'
 #' @param decomp list containing the relevant decomposition parameters.
 #' For the Multi-layered Simplex-lattice design, the following key-value
-#' pairs must be members of decomp:
+#' pairs must be elements of \code{decomp}:
 #'
-#' #' \tabular{ccc}{
-#' \code{key}\tab \code{type}\tab \code{contents}\cr
-#'
-#' ".nobj" \tab Integer > 0 \tab Number of Objectives\cr
-#' "H"    \tab Numeric Array \tab User parameter, h_i > 0\cr
-#' "tau"    \tab Numeric Array \tab User parameter, |tau| = |H| and each tau_i must be unique\cr
-#'}
-#'
-#'
+#' \itemize{
+#'   \item \code{decomp$H}: array of positive integers representing the
+#'                          \code{H} values to be used by the SLD decomposition
+#'                          at each layer (see \code{\link{decomposition_sld}}
+#'                          for details).
+#'   \item \code{decomp$tau}: array of scale multipliers for each layer,
+#'         \eqn{0 < \tau_i \le 1}, \eqn{\tau_i != \tau_j} for all \eqn{i != j}.
+#'         Must have the same lenght as \code{decomp$H}.
+#'   \item \code{decomp$.nobj}: integer value, \code{decomp$.nobj > 1}. Number of
+#'         objectives of the problem.
+#' }
 #' @param ... other parameters (unused, included for compatibility with
 #' generic call)
 #'

--- a/R/decomposition_msld.R
+++ b/R/decomposition_msld.R
@@ -39,29 +39,36 @@ decomposition_msld <- function(decomp, ...){
   # Validating parameters
   assertthat::assert_that(
     assertthat::has_name(decomp,"H"),
+    length(decomp$H) > 1,
     all(sapply(decomp$H,assertthat::is.count)), ## there must be a cleaner way (all elements of H are count)
+    #
+    # ^^^^^ I think it's fine. If you want an alternative (more verbose though):
+    # is.integer(decomp$H) || all(decomp$H == as.integer(decomp$H)),
+    # all(decomp$H > 0),
+    #
     assertthat::has_name(decomp,"tau"),
-    all(decomp$tau >= 0 & decomp$tau < 1),
+    is_within(decomp$tau, strict = c(TRUE, FALSE)), # is_within from utils.R
     assertthat::are_equal(decomp$tau,unique(decomp$tau)),
     assertthat::are_equal(length(decomp$H),length(decomp$tau)),
-    length(decomp$H) > 1,
     assertthat::has_name(decomp,".nobj"),
     assertthat::is.count(decomp$.nobj),
     decomp$.nobj >= 2)
 
   # Calling SLD on each (h,tau) pair
-  W = mapply(decomp$H,decomp$tau,MoreArgs=list(decomp$.nobj),
-             FUN = function(h,t,nobj) {
+  W = mapply(decomp$H,
+             decomp$tau,
+             MoreArgs = list(decomp$.nobj),
+             FUN = function(h, t, nobj) {
                 # building parameter list for decomposition_sld
-                x = list(H=h,.nobj=nobj)
+                x = list(H = h, .nobj = nobj)
                 l = decomposition_sld(x)
                 # scaling down vectors
-                l = l*t + (1-t)/nobj
+                l = l * t + (1 - t) / nobj
                 return(l)
              })
 
   # putting the results together and fixing funky rownames
-  if (is.list(W)) {W <- do.call(rbind,W)}
+  if (is.list(W)) {W <- do.call(rbind, W)}
   rownames(W) <- NULL
   return(W)
 }

--- a/man/decomposition_msld.Rd
+++ b/man/decomposition_msld.Rd
@@ -7,7 +7,21 @@
 decomposition_msld(decomp, ...)
 }
 \arguments{
-\item{decomp}{TODO}
+\item{decomp}{list containing the relevant decomposition parameters.
+For the Multi-layered Simplex-lattice design, the following key-value
+pairs must be elements of \code{decomp}:
+
+\itemize{
+  \item \code{decomp$H}: array of positive integers representing the
+                         \code{H} values to be used by the SLD decomposition
+                         at each layer (see \code{\link{decomposition_sld}}
+                         for details).
+  \item \code{decomp$tau}: array of scale multipliers for each layer,
+        \eqn{0 < \tau_i \le 1}, \eqn{\tau_i != \tau_j} for all \eqn{i != j}.
+        Must have the same lenght as \code{decomp$H}.
+  \item \code{decomp$.nobj}: integer value, \code{decomp$.nobj > 1}. Number of
+        objectives of the problem.
+}}
 
 \item{...}{other parameters (unused, included for compatibility with
 generic call)}

--- a/man/variation_sbx.Rd
+++ b/man/variation_sbx.Rd
@@ -4,7 +4,7 @@
 \alias{variation_sbx}
 \title{Simulated binary crossover}
 \usage{
-variation_sbx(X, P, etax, pc = 1, eps = 1e-06)
+variation_sbx(X, P, etax, pc = 1, eps = 1e-06, ...)
 }
 \arguments{
 \item{X}{Population matrix}
@@ -17,6 +17,9 @@ variation_sbx(X, P, etax, pc = 1, eps = 1e-06)
 \item{pc}{variable-wise probability of recombination}
 
 \item{eps}{smallest difference considered for recombination}
+
+\item{...}{other parameters (unused, included for compatibility with
+generic call)}
 }
 \value{
 Matrix \code{X}' containing the recombined population


### PR DESCRIPTION
Please take a look at **decomposition_msld.R**, I did some minor style-related changes:

- suggested an alternative to your `sapply` check (don't know if it's "cleaner" - let me know what you think)
- changed the test on the values of _decomp$tau_ using function `is_within` from **utils.R**
- added spaces around operators and after all commas, for conformity with the style I've been using in the rest of the package (which draws heavily from [http://adv-r.had.co.nz/Style.html](http://adv-r.had.co.nz/Style.html) )
- Added more detail to the documentation, and changed the table to an itemized list (the table was getting too cluttered).

Cheers,